### PR TITLE
Modified retry limit and sleep time to account for wildfire behavior

### DIFF
--- a/cbopensource/connectors/wildfire/bridge.py
+++ b/cbopensource/connectors/wildfire/bridge.py
@@ -132,9 +132,9 @@ class WildfireProvider(BinaryAnalysisProvider):
     def analyze_binary(self, md5sum, binary_file_stream):
         self.submit_wildfire(md5sum, binary_file_stream)
 
-        retries = 20
+        retries = 15
         while retries:
-            time.sleep(30)
+            time.sleep(60)
             result = self.check_result_for(md5sum)
             if result:
                 return result


### PR DESCRIPTION
Wildfire analysis can take anywhere from 1 second to 15 minutes.  A retry limit of 20 with a sleep of 30 does not account for the full 15 minute period it could take to analyze a binary and queries the api more frequently than necessary.  A retry of 15 and sleep of 60sec is more gentle on the api and accounts for the full time period it can take to analyze a binary.